### PR TITLE
Refactor UriProvider to use new C# 6 string syntax.

### DIFF
--- a/WundergroundNetLib/DataProvider.cs
+++ b/WundergroundNetLib/DataProvider.cs
@@ -30,7 +30,7 @@ namespace WundergroundNetLib
             //return JsonConvert.DeserializeObject<T>(jsonData);
             #endregion
 
-            //New Code that calls Asynchornious method for downloading JSON file
+            //New Code that calls async method for downloading JSON file
             Task<string> jsonData = jsonProvider.DownloadJsonStringAsync(pwsUri);
             return JsonConvert.DeserializeObject<T>(jsonData.Result);
 

--- a/WundergroundNetLib/JsonProvider.cs
+++ b/WundergroundNetLib/JsonProvider.cs
@@ -14,13 +14,13 @@ namespace WundergroundNetLib
         public string DownloadJsonString(Uri uri)
         {
             WebClient webClient = new WebClient();
-            //test
-            Console.WriteLine("JSONPROVIDER: If this goes first then I'm doing this right");
             return webClient.DownloadString(uri);
         }
 
         /// <summary>
-        /// This method does the same job as previous DownloadJsonString method, but this time we download JSON string asynchronously using HttpClient. This is implemented to improve application responsiveness.
+        /// This method does the same job as previous DownloadJsonString method, 
+        /// but this time we download JSON string asynchronously using HttpClient. 
+        /// This is implemented to improve application responsiveness.
         /// </summary>
         /// <param name="uri"></param>
         /// <returns></returns>

--- a/WundergroundNetLib/UriProvider.cs
+++ b/WundergroundNetLib/UriProvider.cs
@@ -20,8 +20,7 @@ namespace WundergroundNetLib
         {
             string wunApiKey = Resources.WundergroundApiKey;
             Uri baseUri = new Uri("http://api.wunderground.com/api/");
-            return new Uri(baseUri, string.Format("{0}/pws/{1}/q/pws:{2}.json", wunApiKey, dataFeatures, location));
-
+            return new Uri(baseUri, string.Format($"{wunApiKey}/pws/{dataFeatures}/q/pws:{location}.json"));
             // Complete uri will look something like: http://api.wunderground.com/api/YourApiKey/pws/conditions/q/pws:ISOUTHLA34.json
         }
     }


### PR DESCRIPTION
Running the unit tests created by @nzjohnah shows that the UriProvider, CreateWunUri method is returns an accurate Uri.